### PR TITLE
new Date() wrapper

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -108,12 +108,12 @@ const getUserData = (data, checks) => {
       { errors: { $className: 'isVerified' } });
   }
 
-  if (checks.includes('verifyNotExpired') && user.verifyExpires < Date.now()) {
+  if (checks.includes('verifyNotExpired') && user.verifyExpires < new Date()) {
     throw new errors.BadRequest('Verification token has expired.',
       { errors: { $className: 'verifyExpired' } });
   }
 
-  if (checks.includes('resetNotExpired') && user.resetExpires < Date.now()) {
+  if (checks.includes('resetNotExpired') && user.resetExpires < new Date()) {
     throw new errors.BadRequest('Password reset token has expired.',
       { errors: { $className: 'resetExpired' } });
   }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -29,7 +29,7 @@ module.exports.addVerification = path => hook => {
       }
 
       hook.data.isVerified = false;
-      hook.data.verifyExpires = Date.now() + options.delay;
+      hook.data.verifyExpires = new Date(Date.now() + options.delay);
       hook.data.verifyToken = longToken;
       hook.data.verifyShortToken = shortToken;
       hook.data.verifyChanges = {};

--- a/src/identityChange.js
+++ b/src/identityChange.js
@@ -41,7 +41,7 @@ module.exports = function identityChange (options, identifyUser, password, chang
     ]))
     .then(([user1, longToken, shortToken]) => {
       const patchToUser = {
-        verifyExpires: Date.now() + options.delay,
+        verifyExpires: new Date(Date.now() + options.delay),
         verifyToken: longToken,
         verifyShortToken: shortToken,
         verifyChanges: changesIdentifyUser

--- a/src/resendVerifySignup.js
+++ b/src/resendVerifySignup.js
@@ -40,7 +40,7 @@ module.exports = function resendVerifySignup (options, identifyUser, notifierOpt
     .then(([user, longToken, shortToken]) =>
       patchUser(user, {
         isVerified: false,
-        verifyExpires: Date.now() + options.delay,
+        verifyExpires: new Date(Date.now() + options.delay),
         verifyToken: longToken,
         verifyShortToken: shortToken
       })

--- a/src/sendResetPwd.js
+++ b/src/sendResetPwd.js
@@ -37,7 +37,7 @@ module.exports = function sendResetPwd (options, identifyUser, notifierOptions) 
     })
     .then(([user, longToken, shortToken]) =>
       Object.assign(user, {
-        resetExpires: Date.now() + options.resetDelay,
+        resetExpires: new Date(Date.now() + options.resetDelay),
         resetToken: concatIDAndHash(user[usersIdName], longToken),
         resetShortToken: concatIDAndHash(user[usersIdName], shortToken)
       })

--- a/src/verifySignup.js
+++ b/src/verifySignup.js
@@ -49,7 +49,7 @@ function verifySignup (options, query, tokens) {
           });
       }
 
-      return eraseVerifyProps(user, user.verifyExpires > Date.now(), user.verifyChanges || {})
+      return eraseVerifyProps(user, user.verifyExpires > new Date(), user.verifyChanges || {})
         .then(user1 => notifier(options.notifier, 'verifySignup', user1))
         .then(user1 => sanitizeUserForClient(user1));
     });

--- a/test/addVerification.test.js
+++ b/test/addVerification.test.js
@@ -375,7 +375,7 @@ describe('hook:addVerification', () => {
 
 function makeDateTime(options1) {
   options1 = options1 || {};
-  return Date.now() + (options1.delay || defaultVerifyDelay);
+  return new Date(Date.now() + (options1.delay || defaultVerifyDelay));
 }
 
 function aboutEqualDateTime(time1, time2, msg, delta) {

--- a/test/feathersStubs.test.js
+++ b/test/feathersStubs.test.js
@@ -9,7 +9,7 @@ const feathersStubs = require('./../test/helpers/feathersStubs');
 
 const now = Date.now();
 const usersDb = [
-  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: now + 50000 },
+  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: new Date(now + 50000) },
   { _id: 'b', email: 'b', isVerified: true, verifyToken: null, verifyExpires: null },
 ];
 

--- a/test/removeVerification.test.js
+++ b/test/removeVerification.test.js
@@ -18,10 +18,10 @@ describe('hook:remove verification', () => {
         password: '0000000000',
         isVerified: true,
         verifyToken: '000',
-        verifyExpires: Date.now(),
+        verifyExpires: new Date(),
         verifyChanges: {},
         resetToken: '000',
-        resetExpires: Date.now(),
+        resetExpires: new Date(),
       },
     };
   });

--- a/test/resendVerifySignup.test.js
+++ b/test/resendVerifySignup.test.js
@@ -16,7 +16,7 @@ const defaultVerifyDelay = 1000 * 60 * 60 * 24 * 5; // 5 days
 
 const now = Date.now();
 const usersDb = [
-  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyShortToken: '00099', verifyExpires: now + 50000, username: 'Doe' },
+  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyShortToken: '00099', verifyExpires: new Date(now + 50000), username: 'Doe' },
   { _id: 'b', email: 'b', isVerified: true, verifyToken: null, verifyShortToken: null, verifyExpires: null },
   { _id: 'c', email: 'c', isVerified: true, verifyToken: '999', verifyShortToken: '99900', verifyExpires: null }, // impossible
 ];
@@ -392,7 +392,7 @@ function notifier(action, user, notifierOptions, newEmail) {
 
 function makeDateTime(options1) {
   options1 = options1 || {};
-  return Date.now() + (options1.delay || defaultVerifyDelay);
+  return new Date(Date.now() + (options1.delay || defaultVerifyDelay));
 }
 
 function aboutEqualDateTime(time1, time2, msg, delta) {

--- a/test/resetPwdLong.test.js
+++ b/test/resetPwdLong.test.js
@@ -19,10 +19,10 @@ const usersDbPromise = new Promise((resolve, reject) => {
 
   var users = [
     // The added time interval must be longer than it takes to run ALL the tests
-    { _id: 'a', email: 'a', isVerified: true, resetToken: 'a___000', resetExpires: now + 200000 },
+    { _id: 'a', email: 'a', isVerified: true, resetToken: 'a___000', resetExpires: new Date(now + 200000) },
     { _id: 'b', email: 'b', isVerified: true, resetToken: null, resetExpires: null },
-    { _id: 'c', email: 'c', isVerified: true, resetToken: 'c___111', resetExpires: now - 200000 },
-    { _id: 'd', email: 'd', isVerified: false, resetToken: 'd___222', resetExpires: now - 200000 },
+    { _id: 'c', email: 'c', isVerified: true, resetToken: 'c___111', resetExpires: new Date(now - 200000) },
+    { _id: 'd', email: 'd', isVerified: false, resetToken: 'd___222', resetExpires: new Date(now - 200000) },
   ];
 
   var promises = [];

--- a/test/resetPwdShort.test.js
+++ b/test/resetPwdShort.test.js
@@ -19,10 +19,10 @@ const usersDbPromise = new Promise((resolve, reject) => {
 
   var users = [
     // The added time interval must be longer than it takes to run ALL the tests
-    { _id: 'a', email: 'a', username: 'aa', isVerified: true, resetToken: '000', resetShortToken: 'a___00099', resetExpires: now + 200000 },
+    { _id: 'a', email: 'a', username: 'aa', isVerified: true, resetToken: '000', resetShortToken: 'a___00099', resetExpires: new Date(now + 200000) },
     { _id: 'b', email: 'b', username: 'bb', isVerified: true, resetToken: null, resetShortToken: null, resetExpires: null },
-    { _id: 'c', email: 'c', username: 'cc', isVerified: true, resetToken: '111', resetShortToken: 'c___11199', resetExpires: now - 200000 },
-    { _id: 'd', email: 'd', username: 'dd', isVerified: false, resetToken: '222', resetShortToken: 'd___22299', resetExpires: now - 200000 },
+    { _id: 'c', email: 'c', username: 'cc', isVerified: true, resetToken: '111', resetShortToken: 'c___11199', resetExpires: new Date(now - 200000) },
+    { _id: 'd', email: 'd', username: 'dd', isVerified: false, resetToken: '222', resetShortToken: 'd___22299', resetExpires: new Date(now - 200000) },
   ];
 
   var promises = [];

--- a/test/sendResetPwd.test.js
+++ b/test/sendResetPwd.test.js
@@ -14,7 +14,7 @@ const defaultResetDelay = 1000 * 60 * 60 * 2; // 2 hours
 
 const now = Date.now();
 const usersDb = [
-  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: now + 50000 },
+  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: new Date(now + 50000) },
   { _id: 'b', email: 'b', isVerified: true, verifyToken: null, verifyExpires: null },
 ];
 
@@ -272,7 +272,7 @@ function notifier(action, user, notifierOptions, newEmail) {
 
 function makeDateTime(options1) {
   options1 = options1 || {};
-  return Date.now() + (options1.delay || defaultResetDelay);
+  return new Date(Date.now() + (options1.delay || defaultResetDelay));
 }
 
 function aboutEqualDateTime(time1, time2, msg, delta) {

--- a/test/verifySignupLong.test.js
+++ b/test/verifySignupLong.test.js
@@ -13,11 +13,11 @@ const SpyOn = require('./helpers/basicSpy');
 const now = Date.now();
 const usersDb = [
   // The added time interval must be longer than it takes to run ALL the tests
-  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: now + 200000 },
+  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: new Date(now + 200000) },
   { _id: 'b', email: 'b', isVerified: false, verifyToken: null, verifyExpires: null },
-  { _id: 'c', email: 'c', isVerified: false, verifyToken: '111', verifyExpires: now - 200000 },
-  { _id: 'd', email: 'd', isVerified: true, verifyToken: '222', verifyExpires: now - 200000 },
-  { _id: 'e', email: 'e', isVerified: true, verifyToken: '800', verifyExpires: now + 200000,
+  { _id: 'c', email: 'c', isVerified: false, verifyToken: '111', verifyExpires: new Date(now - 200000) },
+  { _id: 'd', email: 'd', isVerified: true, verifyToken: '222', verifyExpires: new Date(now - 200000) },
+  { _id: 'e', email: 'e', isVerified: true, verifyToken: '800', verifyExpires: new Date(now + 200000),
     verifyChanges: { cellphone: '800' } },
 ];
 

--- a/test/verifySignupShort.test.js
+++ b/test/verifySignupShort.test.js
@@ -13,11 +13,11 @@ const SpyOn = require('./helpers/basicSpy');
 const now = Date.now();
 const usersDb = [
   // The added time interval must be longer than it takes to run ALL the tests
-  { _id: 'a', email: 'a', username: 'aa', isVerified: false, verifyToken: '000', verifyShortToken: '00099', verifyExpires: now + 200000 },
+  { _id: 'a', email: 'a', username: 'aa', isVerified: false, verifyToken: '000', verifyShortToken: '00099', verifyExpires: new Date(now + 200000) },
   { _id: 'b', email: 'b', username: 'bb', isVerified: false, verifyToken: null, verifyShortToken: null, verifyExpires: null },
-  { _id: 'c', email: 'c', username: 'cc', isVerified: false, verifyToken: '111', verifyShortToken: '11199', verifyExpires: now - 200000 },
-  { _id: 'd', email: 'd', username: 'dd', isVerified: true, verifyToken: '222', verifyShortToken: '22299', verifyExpires: now - 200000 },
-  { _id: 'e', email: 'e', username: 'ee', isVerified: true, verifyToken: '800', verifyShortToken: '80099', verifyExpires: now + 200000,
+  { _id: 'c', email: 'c', username: 'cc', isVerified: false, verifyToken: '111', verifyShortToken: '11199', verifyExpires: new Date(now - 200000) },
+  { _id: 'd', email: 'd', username: 'dd', isVerified: true, verifyToken: '222', verifyShortToken: '22299', verifyExpires: new Date(now - 200000) },
+  { _id: 'e', email: 'e', username: 'ee', isVerified: true, verifyToken: '800', verifyShortToken: '80099', verifyExpires: new Date(now + 200000),
     verifyChanges: { cellphone: '800' } },
 ];
 


### PR DESCRIPTION
This PR wrap every `Date.now()` into `new Date()`, to work with Date instead of String, and fix https://github.com/feathers-plus/feathers-authentication-management/issues/86.