### PR TITLE
Fix reset password short reset token to work as advertised in the documentation

### DIFF
--- a/src/resetPassword.js
+++ b/src/resetPassword.js
@@ -47,19 +47,19 @@ function resetPassword (options, query, tokens, password) {
     checkProps.push('isVerified');
   }
 
-  var id;
+  let userPromise;
 
   if (tokens.resetToken) {
-    id = deconstructId(tokens.resetToken);
+    let id = deconstructId(tokens.resetToken);
+    userPromise = users.get(id).then(data => getUserData(data, checkProps));
   } else if (tokens.resetShortToken) {
-    id = deconstructId(tokens.resetShortToken);
+    userPromise = users.find({query}).then(data => getUserData(data, checkProps));
   } else {
     return Promise.reject(new errors.BadRequest('resetToken or resetShortToken is missing'));
   }
 
   return Promise.all([
-    users.get(id)
-      .then(data => getUserData(data, checkProps)),
+    userPromise,
     hashPassword(options.app, password)
   ])
     .then(([user, hashPassword]) => {

--- a/src/sendResetPwd.js
+++ b/src/sendResetPwd.js
@@ -39,7 +39,7 @@ module.exports = function sendResetPwd (options, identifyUser, notifierOptions) 
       Object.assign(user, {
         resetExpires: Date.now() + options.resetDelay,
         resetToken: concatIDAndHash(user[usersIdName], longToken),
-        resetShortToken: concatIDAndHash(user[usersIdName], shortToken)
+        resetShortToken: shortToken
       })
     )
     .then(user => notifier(options.notifier, 'sendResetPwd', user, notifierOptions).then(() => user))

--- a/test/resetPwdShort.test.js
+++ b/test/resetPwdShort.test.js
@@ -19,14 +19,14 @@ const usersDbPromise = new Promise((resolve, reject) => {
 
   var users = [
     // The added time interval must be longer than it takes to run ALL the tests
-    { _id: 'a', email: 'a', username: 'aa', isVerified: true, resetToken: '000', resetShortToken: 'a___00099', resetExpires: now + 200000 },
+    { _id: 'a', email: 'a', username: 'aa', isVerified: true, resetToken: '000', resetShortToken: '00099', resetExpires: now + 200000 },
     { _id: 'b', email: 'b', username: 'bb', isVerified: true, resetToken: null, resetShortToken: null, resetExpires: null },
-    { _id: 'c', email: 'c', username: 'cc', isVerified: true, resetToken: '111', resetShortToken: 'c___11199', resetExpires: now - 200000 },
-    { _id: 'd', email: 'd', username: 'dd', isVerified: false, resetToken: '222', resetShortToken: 'd___22299', resetExpires: now - 200000 },
+    { _id: 'c', email: 'c', username: 'cc', isVerified: true, resetToken: '111', resetShortToken: '11199', resetExpires: now - 200000 },
+    { _id: 'd', email: 'd', username: 'dd', isVerified: false, resetToken: '222', resetShortToken: '22299', resetExpires: now - 200000 },
   ];
 
   var promises = [];
-  
+
   users.forEach(item => {
     if(item.resetShortToken) {
       promises.push(
@@ -68,11 +68,11 @@ const usersDbPromise = new Promise((resolve, reject) => {
             done();
           })
         });
-  
+
         it('verifies valid token', (done) => {
-          const resetShortToken = 'a___00099';
+          const resetShortToken = '00099';
           const i = 0;
-    
+
           authManagement.create({ action: 'resetPwdShort', value: {
             token: resetShortToken, password, user: { email: db[i].email }
           } })
@@ -93,7 +93,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
         });
 
         it('user is sanitized', (done) => {
-          const resetShortToken = 'a___00099';
+          const resetShortToken = '00099';
           const i = 0;
 
           authManagement.create({ action: 'resetPwdShort', value: {
@@ -115,7 +115,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
         });
 
         it('handles multiple user ident', (done) => {
-          const resetShortToken = 'a___00099';
+          const resetShortToken = '00099';
           const i = 0;
 
           authManagement.create({ action: 'resetPwdShort', value: {
@@ -137,7 +137,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
         });
 
         it('requires user ident', (done) => {
-          const resetShortToken = 'a___00099';
+          const resetShortToken = '00099';
           const i = 0;
 
           authManagement.create({ action: 'resetPwdShort', value: {
@@ -155,7 +155,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
         });
 
         it('throws on non-configured user ident', (done) => {
-          const resetShortToken = 'a___00099';
+          const resetShortToken = '00099';
           const i = 0;
 
           authManagement.create({ action: 'resetPwdShort', value: {
@@ -268,25 +268,25 @@ const usersDbPromise = new Promise((resolve, reject) => {
             done();
           })
         });
-  
+
         it('verifies valid token', (done) => {
-          const resetShortToken = 'a___00099';
+          const resetShortToken = '00099';
           const i = 0;
-    
+
           authManagement.create({
               action: 'resetPwdShort',
               value: { token: resetShortToken, user: { email: db[i].email }, password } })
             .then(user => {
               assert.strictEqual(user.isVerified, true, 'user.isVerified not true');
-  
+
               assert.strictEqual(db[i].isVerified, true, 'isVerified not true');
               assert.strictEqual(db[i].resetToken, null, 'resetToken not null');
               assert.strictEqual(db[i].resetExpires, null, 'resetExpires not null');
-  
+
               const hash = db[i].password;
               assert.isString(hash, 'password not a string');
               assert.equal(hash.length, 60, 'password wrong length');
-  
+
               assert.deepEqual(
                 spyNotifier.result()[0].args,
                 [
@@ -294,7 +294,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
                   Object.assign({}, sanitizeUserForEmail(db[i])),
                   {}
                 ]);
-  
+
               done();
             })
             .catch(err => {


### PR DESCRIPTION
This PR reverts the library to work as previously with short reset tokens before PR #68. Meaning that short tokens don't get prepended with a user ID as that makes them not usable for their purpose. Also, to support this the method for fetching the user when resetting the password is reverted back to querying with a passed in user identity in case of the short token.

Changed the tests to reflect the short token not having ID prepended.

Check it out and let me know any improvements!