### PR TITLE
hashPassword workaround verbage

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -150,7 +150,7 @@ The following `user` item might also contain the following props:
 The `users` service is expected to be already configured.
 Its `patch` method is used to update the password when needed,
 and this module hashes the password before it is passed to `patch`,
-therefore `patch` may *not* have a `auth.hashPassword()` hook.
+therefore `patch` may *not* have a `auth.hashPassword()` hook. In cases where you only need hashPassword for externally submitted patch calls, you may use `iff(isProvider('external'), hashPassword())` on the patch hook.
 
 The user must be signed in before being allowed to change their password or communication values.
 The service, for feathers-authenticate v1.x, requires hooks similar to:


### PR DESCRIPTION
I almost forgot about isProvider and thought about making a really complicated hook with authManagement to deal with the issue. This is far simpler for this common use case.