### PR TITLE
add ability to accept a custom password field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - node
-- '6'
+- '8'
 addons:
   code_climate:
     repo_token: 38bd61635a3a37ffeb2d2de7d6a27c416d2c13538ad1bc4b0c771b0b20bdd392

--- a/docs.md
+++ b/docs.md
@@ -212,6 +212,7 @@ authManagement.create({ action: 'verifySignupShort',
 // send forgotten password notification
 authManagement.create({ action: 'sendResetPwd',
   value: identifyUser, // {email}, {token: verifyToken}
+  passwordField, // field the password is stored. default: 'password'
   notifierOptions, // options passed to options.notifier, e.g. {preferredComm: 'email'}
 })
 
@@ -295,7 +296,7 @@ authManagement.verifySignupLong(verifyToken)
 authManagement.verifySignupShort(verifyShortToken, identifyUser)
 
 // send forgotten password notification
-authManagement.sendResetPwd(identifyUser, notifierOptions)
+authManagement.sendResetPwd(identifyUser, notifierOptions, passwordField)
 
 // forgotten password verification with long token
 authManagement.resetPwdLong(resetToken, password, passwordField)

--- a/docs.md
+++ b/docs.md
@@ -220,6 +220,7 @@ authManagement.create({ action: 'resetPwdLong',
   value: {
     token, // compares to .resetToken
     password, // new password
+    passwordField, // field the password is stored. default: 'password'
   },
 })
 
@@ -229,6 +230,7 @@ authManagement.create({ action: 'resetPwdShort',
     user: identifyUser, // identify user, e.g. {email: 'a@a.com'}. See options.identifyUserProps.
     token, // compares to .resetShortToken
     password, // new password
+    passwordField, // field the password is stored. default: 'password'
   },
 })
 
@@ -238,6 +240,7 @@ authManagement.create({ action: 'passwordChange',
     user: identifyUser, // identify user, e.g. {email: 'a@a.com'}. See options.identifyUserProps.
     oldPassword, // old password for verification
     password, // new password
+    passwordField, // field the password is stored. default: 'password'
   },
 })
 
@@ -247,6 +250,7 @@ authManagement.create({ action: 'identityChange',
     user: identifyUser, // identify user, e.g. {email: 'a@a.com'}. See options.identifyUserProps.
     password, // current password for verification
     changes, // {email: 'a@a.com'} or {email: 'a@a.com', cellphone: '+1-800-555-1212'}
+    passwordField, // field the password is stored. default: 'password'
   },
 })
 
@@ -294,16 +298,16 @@ authManagement.verifySignupShort(verifyShortToken, identifyUser)
 authManagement.sendResetPwd(identifyUser, notifierOptions)
 
 // forgotten password verification with long token
-authManagement.resetPwdLong(resetToken, password)
+authManagement.resetPwdLong(resetToken, password, passwordField)
 
 // forgotten password verification with short token
-authManagement.resetPwdShort(resetShortToken, identifyUser, password)
+authManagement.resetPwdShort(resetShortToken, identifyUser, password, passwordField)
 
 // change password
-authManagement.passwordChange(oldPassword, password, identifyUser)
+authManagement.passwordChange(oldPassword, password, identifyUser, passwordField)
 
 // change identity
-authManagement.identityChange(password, changesIdentifyUser, identifyUser)
+authManagement.identityChange(password, changesIdentifyUser, identifyUser, passwordField)
 
 // Authenticate user and log on if user is verified. v0.x only.
 authManagement.authenticate(email, password)

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,7 +368,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -736,7 +736,7 @@
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
       "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
       "dev": true
     },
@@ -1319,7 +1319,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2230,14 +2230,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2252,20 +2250,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2382,8 +2377,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2395,7 +2389,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2410,7 +2403,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2418,14 +2410,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2444,7 +2434,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2525,8 +2514,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2538,7 +2526,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2660,7 +2647,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2942,7 +2928,7 @@
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
@@ -3610,13 +3596,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4425,7 +4411,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4489,7 +4475,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -4552,7 +4538,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,7 +368,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -736,7 +736,7 @@
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
       "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
       "dev": true
     },
@@ -1319,7 +1319,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2230,12 +2230,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2250,17 +2252,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2377,7 +2382,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2389,6 +2395,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2403,6 +2410,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2410,12 +2418,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2434,6 +2444,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2514,7 +2525,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2526,6 +2538,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2647,6 +2660,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2928,7 +2942,7 @@
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
@@ -3596,13 +3610,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4411,7 +4425,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4475,7 +4489,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -4538,7 +4552,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/src/client.js
+++ b/src/client.js
@@ -32,9 +32,10 @@ function AuthManagement (app) { // eslint-disable-line no-unused-vars
     value: { user: identifyUser, token: verifyShortToken }
   }, {});
 
-  this.sendResetPwd = (identifyUser, notifierOptions) => authManagement.create({
+  this.sendResetPwd = (identifyUser, notifierOptions, passwordField) => authManagement.create({
     action: 'sendResetPwd',
     value: identifyUser,
+    passwordField,
     notifierOptions
   }, {});
 

--- a/src/client.js
+++ b/src/client.js
@@ -38,24 +38,24 @@ function AuthManagement (app) { // eslint-disable-line no-unused-vars
     notifierOptions
   }, {});
 
-  this.resetPwdLong = (resetToken, password) => authManagement.create({
+  this.resetPwdLong = (resetToken, password, passwordField) => authManagement.create({
     action: 'resetPwdLong',
-    value: { token: resetToken, password }
+    value: { token: resetToken, password, passwordField }
   }, {});
 
-  this.resetPwdShort = (resetShortToken, identifyUser, password) => authManagement.create({
+  this.resetPwdShort = (resetShortToken, identifyUser, password, passwordField) => authManagement.create({
     action: 'resetPwdShort',
-    value: { user: identifyUser, token: resetShortToken, password }
+    value: { user: identifyUser, token: resetShortToken, password, passwordField }
   }, {});
 
-  this.passwordChange = (oldPassword, password, identifyUser) => authManagement.create({
+  this.passwordChange = (oldPassword, password, identifyUser, passwordField) => authManagement.create({
     action: 'passwordChange',
-    value: { user: identifyUser, oldPassword, password }
+    value: { user: identifyUser, oldPassword, password, passwordField }
   }, {});
 
-  this.identityChange = (password, changesIdentifyUser, identifyUser) => authManagement.create({
+  this.identityChange = (password, changesIdentifyUser, identifyUser, passwordField) => authManagement.create({
     action: 'identityChange',
-    value: { user: identifyUser, password, changes: changesIdentifyUser }
+    value: { user: identifyUser, password, changes: changesIdentifyUser, passwordField }
   }, {});
 
   this.authenticate = (email, password, cb) => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -145,7 +145,7 @@ const ensureFieldHasChanged = (obj1, obj2) => (field) => {
   return obj1 && obj2 && obj1[field] !== obj2[field];
 };
 
-const sanitizeUserForClient = user => {
+const sanitizeUserForClient = (additionalPrivateProps) => (user) => {
   const user1 = cloneObject(user);
 
   delete user1.password;
@@ -156,6 +156,12 @@ const sanitizeUserForClient = user => {
   delete user1.resetExpires;
   delete user1.resetToken;
   delete user1.resetShortToken;
+
+  if (Array.isArray(additionalPrivateProps)) {
+    additionalPrivateProps.forEach(prop => {
+      delete user1[prop];
+    });
+  }
 
   return user1;
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -145,7 +145,7 @@ const ensureFieldHasChanged = (obj1, obj2) => (field) => {
   return obj1 && obj2 && obj1[field] !== obj2[field];
 };
 
-const sanitizeUserForClient = (additionalPrivateProps) => (user) => {
+const sanitizeUserForClient = (user) => {
   const user1 = cloneObject(user);
 
   delete user1.password;
@@ -156,12 +156,6 @@ const sanitizeUserForClient = (additionalPrivateProps) => (user) => {
   delete user1.resetExpires;
   delete user1.resetToken;
   delete user1.resetShortToken;
-
-  if (Array.isArray(additionalPrivateProps)) {
-    additionalPrivateProps.forEach(prop => {
-      delete user1[prop];
-    });
-  }
 
   return user1;
 };

--- a/src/identityChange.js
+++ b/src/identityChange.js
@@ -8,13 +8,15 @@ const {
   getLongToken,
   getShortToken,
   ensureObjPropsValid,
+  ensureValuesAreStrings,
   comparePasswords,
   notifier
 } = require('./helpers');
 
-module.exports = function identityChange (options, identifyUser, password, changesIdentifyUser) {
+module.exports = function identityChange (options, identifyUser, password, changesIdentifyUser, passwordFieldName) {
   // note this call does not update the authenticated user info in hooks.params.user.
   debug('identityChange', password, changesIdentifyUser);
+  const passwordField = passwordFieldName || 'password';
   const users = options.app.service(options.service);
   const usersIdName = users.id;
   const {
@@ -23,6 +25,7 @@ module.exports = function identityChange (options, identifyUser, password, chang
 
   return Promise.resolve()
     .then(() => {
+      ensureValuesAreStrings(passwordField);
       ensureObjPropsValid(identifyUser, options.identifyUserProps);
       ensureObjPropsValid(changesIdentifyUser, options.identifyUserProps);
 
@@ -34,7 +37,7 @@ module.exports = function identityChange (options, identifyUser, password, chang
       user1,
       getLongToken(options.longTokenLen),
       getShortToken(options.shortTokenLen, options.shortTokenDigits),
-      comparePasswords(password, user1.password,
+      comparePasswords(password, user1[passwordField],
         () => new errors.BadRequest('Password is incorrect.',
           { errors: { password: 'Password is incorrect.', $className: 'badParams' } })
       )

--- a/src/passwordChange.js
+++ b/src/passwordChange.js
@@ -12,17 +12,21 @@ const {
   notifier
 } = require('./helpers');
 
-module.exports = function passwordChange (options, identifyUser, oldPassword, password) {
-  debug('passwordChange', oldPassword, password);
+module.exports = function passwordChange (options, identifyUser, oldPassword, password, passwordFieldName) {
+  const action = 'passwordChange';
+  const passwordField = passwordFieldName || 'password';
   const users = options.app.service(options.service);
   const usersIdName = users.id;
+  const errMsg = `Current ${passwordField} is incorrect.`;
   const {
     sanitizeUserForClient
   } = options;
 
+  debug(action, `field<${passwordField}>`, oldPassword, password);
+
   return Promise.resolve()
     .then(() => {
-      ensureValuesAreStrings(oldPassword, password);
+      ensureValuesAreStrings(passwordField, oldPassword, password);
       ensureObjPropsValid(identifyUser, options.identifyUserProps);
 
       return users.find({ query: identifyUser })
@@ -31,17 +35,17 @@ module.exports = function passwordChange (options, identifyUser, oldPassword, pa
     .then(user1 => Promise.all([
       user1,
       hashPassword(options.app, password),
-      comparePasswords(oldPassword, user1.password,
-        () => new errors.BadRequest('Current password is incorrect.',
-          { errors: { oldPassword: 'Current password is incorrect.' } })
+      comparePasswords(oldPassword, user1[passwordField],
+        () => new errors.BadRequest(errMsg,
+          { errors: { oldPassword: errMsg } })
       )
     ]))
     .then(([user1, hashedPassword]) => // value from comparePassword is not needed
       patchUser(user1, {
-        password: hashedPassword
+        [passwordField]: hashedPassword
       })
     )
-    .then(user1 => notifier(options.notifier, 'passwordChange', user1))
+    .then(user1 => notifier(options.notifier, action, user1, { passwordField }))
     .then(user1 => sanitizeUserForClient(user1));
 
   function patchUser (user1, patchToUser) {

--- a/src/passwordChange.js
+++ b/src/passwordChange.js
@@ -22,7 +22,7 @@ module.exports = function passwordChange (options, identifyUser, oldPassword, pa
     sanitizeUserForClient
   } = options;
 
-  debug(action, `field<${passwordField}>`, oldPassword, password);
+  debug(action, `field:${passwordField}`, oldPassword, password);
 
   return Promise.resolve()
     .then(() => {

--- a/src/resetPassword.js
+++ b/src/resetPassword.js
@@ -14,27 +14,28 @@ const {
   deconstructId
 } = require('./helpers');
 
-module.exports.resetPwdWithLongToken = function (options, resetToken, password) {
+module.exports.resetPwdWithLongToken = function (options, resetToken, password, passwordField = 'password') {
   return Promise.resolve()
     .then(() => {
-      ensureValuesAreStrings(resetToken, password);
+      ensureValuesAreStrings(passwordField, resetToken, password);
 
       return resetPassword(options, { resetToken }, { resetToken }, password);
     });
 };
 
-module.exports.resetPwdWithShortToken = function (options, resetShortToken, identifyUser, password) {
+module.exports.resetPwdWithShortToken = function (options, resetShortToken, identifyUser, password, passwordField = 'password') {
   return Promise.resolve()
     .then(() => {
-      ensureValuesAreStrings(resetShortToken, password);
+      ensureValuesAreStrings(passwordField, resetShortToken, password);
       ensureObjPropsValid(identifyUser, options.identifyUserProps);
 
       return resetPassword(options, identifyUser, { resetShortToken }, password);
     });
 };
 
-function resetPassword (options, query, tokens, password) {
+function resetPassword (options, query, tokens, password, passwordFieldName) {
   debug('resetPassword', query, tokens, password);
+  const passwordField = passwordFieldName || 'password';
   const users = options.app.service(options.service);
   const usersIdName = users.id;
   const {
@@ -85,12 +86,12 @@ function resetPassword (options, query, tokens, password) {
     })
     .then(([user, hashedPassword]) => {
       return patchUser(user, {
-        password: hashedPassword,
+        [passwordField]: hashedPassword,
         resetToken: null,
         resetShortToken: null,
         resetExpires: null
       })
-        .then(user1 => notifier(options.notifier, 'resetPwd', user1))
+        .then(user1 => notifier(options.notifier, 'resetPwd', user1, { passwordField }))
         .then(user1 => sanitizeUserForClient(user1));
     });
 

--- a/src/sendResetPwd.js
+++ b/src/sendResetPwd.js
@@ -13,8 +13,10 @@ const {
   concatIDAndHash
 } = require('./helpers');
 
-module.exports = function sendResetPwd (options, identifyUser, notifierOptions) {
+module.exports = function sendResetPwd (options, identifyUser, notifierOptions, passwordFieldName) {
   debug('sendResetPwd');
+  const passwordField = passwordFieldName || 'password';
+  const notifierOpts = Object.assign({}, notifierOptions, { passwordField });
   const users = options.app.service(options.service);
   const usersIdName = users.id;
   const {
@@ -42,7 +44,7 @@ module.exports = function sendResetPwd (options, identifyUser, notifierOptions) 
         resetShortToken: shortToken
       })
     )
-    .then(user => notifier(options.notifier, 'sendResetPwd', user, notifierOptions).then(() => user))
+    .then(user => notifier(options.notifier, 'sendResetPwd', user, notifierOpts).then(() => user))
     .then(user => Promise.all([
       user,
       hashPassword(options.app, user.resetToken),

--- a/src/service.js
+++ b/src/service.js
@@ -24,13 +24,13 @@ const optionsDefault = {
   shortTokenDigits: true,
   resetDelay: 1000 * 60 * 60 * 2, // 2 hours
   delay: 1000 * 60 * 60 * 24 * 5, // 5 days
-  identifyUserProps: ['email'],
-  sanitizeUserForClient
+  identifyUserProps: ['email']
 };
 
 module.exports = function (options1 = {}) {
   debug('service being configured.');
   const options = Object.assign({}, optionsDefault, options1);
+  options.sanitizeUserForClient = options.sanitizeUserForClient || sanitizeUserForClient(options.privateProps);
 
   return function () {
     return authManagement(options, this);
@@ -57,16 +57,16 @@ function authManagement (options, app) { // 'function' needed as we use 'this'
         case 'sendResetPwd':
           return sendResetPwd(options, data.value, data.notifierOptions);
         case 'resetPwdLong':
-          return resetPwdWithLongToken(options, data.value.token, data.value.password);
+          return resetPwdWithLongToken(options, data.value.token, data.value.password, data.value.passwordField);
         case 'resetPwdShort':
           return resetPwdWithShortToken(
-            options, data.value.token, data.value.user, data.value.password);
+            options, data.value.token, data.value.user, data.value.password, data.value.passwordField);
         case 'passwordChange':
           return passwordChange(
-            options, data.value.user, data.value.oldPassword, data.value.password);
+            options, data.value.user, data.value.oldPassword, data.value.password, data.value.passwordField);
         case 'identityChange':
           return identityChange(
-            options, data.value.user, data.value.password, data.value.changes);
+            options, data.value.user, data.value.password, data.value.changes, data.value.passwordField);
         case 'options':
           return Promise.resolve(options);
         default:

--- a/src/service.js
+++ b/src/service.js
@@ -24,13 +24,13 @@ const optionsDefault = {
   shortTokenDigits: true,
   resetDelay: 1000 * 60 * 60 * 2, // 2 hours
   delay: 1000 * 60 * 60 * 24 * 5, // 5 days
-  identifyUserProps: ['email']
+  identifyUserProps: ['email'],
+  sanitizeUserForClient
 };
 
 module.exports = function (options1 = {}) {
   debug('service being configured.');
   const options = Object.assign({}, optionsDefault, options1);
-  options.sanitizeUserForClient = options.sanitizeUserForClient || sanitizeUserForClient(options.privateProps);
 
   return function () {
     return authManagement(options, this);

--- a/src/service.js
+++ b/src/service.js
@@ -55,7 +55,7 @@ function authManagement (options, app) { // 'function' needed as we use 'this'
         case 'verifySignupShort':
           return verifySignupWithShortToken(options, data.value.token, data.value.user);
         case 'sendResetPwd':
-          return sendResetPwd(options, data.value, data.notifierOptions);
+          return sendResetPwd(options, data.value, data.notifierOptions, data.passwordField);
         case 'resetPwdLong':
           return resetPwdWithLongToken(options, data.value.token, data.value.password, data.value.passwordField);
         case 'resetPwdShort':

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -122,6 +122,7 @@ describe('client - promise methods', () => {
         assert.deepEqual(spyData, {
           action: 'sendResetPwd',
           value: 'a@a.com',
+          passwordField: undefined,
           notifierOptions: { b: 'b' }
         });
         

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -135,7 +135,7 @@ describe('client - promise methods', () => {
         assert.deepEqual(spyParams, {});
         assert.deepEqual(spyData, {
           action: 'resetPwdLong',
-          value: { token: '000', password: '12345678' }
+          value: { token: '000', password: '12345678', passwordField: undefined }
         });
         
         done();
@@ -148,7 +148,7 @@ describe('client - promise methods', () => {
         assert.deepEqual(spyParams, {});
         assert.deepEqual(spyData, {
           action: 'resetPwdShort',
-          value: { token: '000', user: { email: 'a@a.com' }, password: '12345678' },
+          value: { token: '000', user: { email: 'a@a.com' }, password: '12345678', passwordField: undefined },
         });
         
         done();
@@ -159,7 +159,7 @@ describe('client - promise methods', () => {
     authManagement.passwordChange('12345678', 'password', { email: 'a' })
       .then(() => {
         assert.deepEqual(spyData, {
-          action: 'passwordChange', value: { user: { email: 'a' }, oldPassword: '12345678', password: 'password' },
+          action: 'passwordChange', value: { user: { email: 'a' }, oldPassword: '12345678', password: 'password', passwordField: undefined },
         });
         
         done();
@@ -170,7 +170,7 @@ describe('client - promise methods', () => {
     authManagement.identityChange('12345678', { email: 'b@b.com' }, { username: 'q' })
       .then(() => {
         assert.deepEqual(spyData, {
-          action: 'identityChange', value: { user: { username: 'q' }, password: '12345678',
+          action: 'identityChange', value: { user: { username: 'q' }, password: '12345678', passwordField: undefined,
             changes: { email: 'b@b.com' } },
         });
         

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,7 @@ describe('helpers - sanitization', () => {
       resetToken: 'aaa',
     };
 
-    const result1 = helpers.sanitizeUserForClient()(user);
+    const result1 = helpers.sanitizeUserForClient(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.doesNotThrow(() => JSON.stringify(result1));
@@ -29,7 +29,7 @@ describe('helpers - sanitization', () => {
 
     user.self = user;
 
-    const result1 = helpers.sanitizeUserForClient()(user);
+    const result1 = helpers.sanitizeUserForClient(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.throws(() => JSON.stringify(result1), TypeError);
@@ -49,7 +49,7 @@ describe('helpers - sanitization', () => {
 
     user.self = user;
 
-    const result1 = helpers.sanitizeUserForClient()(user);
+    const result1 = helpers.sanitizeUserForClient(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.doesNotThrow(() => JSON.stringify(result1));
@@ -69,7 +69,7 @@ describe('helpers - sanitization', () => {
 
     user.self = user;
 
-    const result1 = helpers.sanitizeUserForClient()(user);
+    const result1 = helpers.sanitizeUserForClient(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.doesNotThrow(() => JSON.stringify(result1));
@@ -78,7 +78,7 @@ describe('helpers - sanitization', () => {
 
   it('allows for customized sanitize function', (done) => {
     function customSanitizeUserForClient(user) {
-      const user1 = helpers.sanitizeUserForClient()(user)
+      const user1 = helpers.sanitizeUserForClient(user)
       delete user1.sensitiveData
       return user1
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,7 @@ describe('helpers - sanitization', () => {
       resetToken: 'aaa',
     };
 
-    const result1 = helpers.sanitizeUserForClient(user);
+    const result1 = helpers.sanitizeUserForClient()(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.doesNotThrow(() => JSON.stringify(result1));
@@ -29,7 +29,7 @@ describe('helpers - sanitization', () => {
 
     user.self = user;
 
-    const result1 = helpers.sanitizeUserForClient(user);
+    const result1 = helpers.sanitizeUserForClient()(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.throws(() => JSON.stringify(result1), TypeError);
@@ -49,7 +49,7 @@ describe('helpers - sanitization', () => {
 
     user.self = user;
 
-    const result1 = helpers.sanitizeUserForClient(user);
+    const result1 = helpers.sanitizeUserForClient()(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.doesNotThrow(() => JSON.stringify(result1));
@@ -69,7 +69,7 @@ describe('helpers - sanitization', () => {
 
     user.self = user;
 
-    const result1 = helpers.sanitizeUserForClient(user);
+    const result1 = helpers.sanitizeUserForClient()(user);
     const result2 = helpers.sanitizeUserForNotifier(user);
 
     assert.doesNotThrow(() => JSON.stringify(result1));
@@ -78,7 +78,7 @@ describe('helpers - sanitization', () => {
 
   it('allows for customized sanitize function', (done) => {
     function customSanitizeUserForClient(user) {
-      const user1 = helpers.sanitizeUserForClient(user)
+      const user1 = helpers.sanitizeUserForClient()(user)
       delete user1.sensitiveData
       return user1
     }

--- a/test/multiInstances.test.js
+++ b/test/multiInstances.test.js
@@ -18,7 +18,7 @@ const optionsDefault = {
   resetDelay: 1000 * 60 * 60 * 2, // 2 hours
   delay: 1000 * 60 * 60 * 24 * 5, // 5 days
   identifyUserProps: ['email'],
-  sanitizeUserForClient: helpers.sanitizeUserForClient
+  sanitizeUserForClient: helpers.sanitizeUserForClient()
 };
 
 const userMgntOptions = {
@@ -84,35 +84,40 @@ describe('multiple services', () => {
       user.create({ username: 'John Doe' })
         .catch(err => {
           console.log(err);
-          done();
+          done(err);
         })
         .then(result => {
           assert.equal(result.username, 'John Doe');
           assert.equal(result.verifyShortToken.length, 8);
 
           done();
-        });
+        })
+        .catch(done);
     });
 
     it('can call service', (done) => {
       const userMgnt = app.service('authManagement');
 
-      const options = userMgnt.create({ action: 'options' })
+      userMgnt.create({ action: 'options' })
         .catch(err => console.log(err))
         .then(options => {
           assert.property(options, 'app');
           assert.property(options, 'notifier');
+          assert.property(options, 'sanitizeUserForClient');
           delete options.app;
           delete options.notifier;
+          delete options.sanitizeUserForClient;
 
           const expected = Object.assign({}, optionsDefault, userMgntOptions);
           delete expected.app;
           delete expected.notifier;
+          delete expected.sanitizeUserForClient;
 
           assert.deepEqual(options, expected);
 
           done();
-        });
+        })
+        .catch(done);
     });
   });
 
@@ -166,12 +171,15 @@ describe('multiple services', () => {
         .then(options => {
           assert.property(options, 'app');
           assert.property(options, 'notifier');
+          assert.property(options, 'sanitizeUserForClient');
           delete options.app;
           delete options.notifier;
+          delete options.sanitizeUserForClient;
 
           const expected = Object.assign({}, optionsDefault, userMgntOptions);
           delete expected.app;
           delete expected.notifier;
+          delete expected.sanitizeUserForClient;
 
           assert.deepEqual(options, expected);
 
@@ -181,18 +189,23 @@ describe('multiple services', () => {
             .then(options => {
               assert.property(options, 'app');
               assert.property(options, 'notifier');
+              assert.property(options, 'sanitizeUserForClient');
               delete options.app;
               delete options.notifier;
+              delete options.sanitizeUserForClient;
 
               const expected = Object.assign({}, optionsDefault, orgMgntOptions);
               delete expected.app;
               delete expected.notifier;
+              delete expected.sanitizeUserForClient;
 
               assert.deepEqual(options, expected);
 
               done();
             })
-        });
+            .catch(done);
+        })
+        .catch(done);
 
     });
   });

--- a/test/multiInstances.test.js
+++ b/test/multiInstances.test.js
@@ -18,7 +18,7 @@ const optionsDefault = {
   resetDelay: 1000 * 60 * 60 * 2, // 2 hours
   delay: 1000 * 60 * 60 * 24 * 5, // 5 days
   identifyUserProps: ['email'],
-  sanitizeUserForClient: helpers.sanitizeUserForClient()
+  sanitizeUserForClient: helpers.sanitizeUserForClient
 };
 
 const userMgntOptions = {

--- a/test/passwordChange.test.js
+++ b/test/passwordChange.test.js
@@ -95,8 +95,7 @@ describe('passwordChange - setup', () => {
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
 
@@ -117,8 +116,7 @@ describe('passwordChange - setup', () => {
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
 
@@ -139,7 +137,8 @@ describe('passwordChange - setup', () => {
               assert.isString(err.message);
               assert.isNotFalse(err.message);
               done();
-            });
+            })
+            .catch(done);
         });
       });
 
@@ -180,13 +179,12 @@ describe('passwordChange - setup', () => {
                 [
                   'passwordChange',
                   sanitizeUserForEmail(db[i]),
-                  {}
+                  { passwordField: 'password' }
                 ]);
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
       });

--- a/test/resetPwdLong.test.js
+++ b/test/resetPwdLong.test.js
@@ -83,8 +83,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
 
@@ -103,8 +102,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
 
@@ -200,14 +198,13 @@ const usersDbPromise = new Promise((resolve, reject) => {
                 [
                   'resetPwd',
                   Object.assign({}, sanitizeUserForEmail(db[i])),
-                  {}
+                  { passwordField: 'password' }
                 ]);
         
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
       });

--- a/test/resetPwdShort.test.js
+++ b/test/resetPwdShort.test.js
@@ -292,7 +292,7 @@ const usersDbPromise = new Promise((resolve, reject) => {
                 [
                   'resetPwd',
                   Object.assign({}, sanitizeUserForEmail(db[i])),
-                  {}
+                  { passwordField: 'password' }
                 ]);
 
               done();

--- a/test/sendResetPwd.test.js
+++ b/test/sendResetPwd.test.js
@@ -271,7 +271,7 @@ function makeDateTime(options1) {
 }
 
 function aboutEqualDateTime(time1, time2, msg, delta) {
-  delta = delta || 1700;
+  delta = delta || 2000;
   const diff = Math.abs(time1 - time2);
   assert.isAtMost(diff, delta, msg || `times differ by ${diff}ms`);
 }

--- a/test/sendResetPwd.test.js
+++ b/test/sendResetPwd.test.js
@@ -235,7 +235,7 @@ const usersDb = [
                 expected[1], 
                 {
                   resetToken: db[i].resetToken,
-                  resetShortToken: db[i].resetShortToken
+                  resetShortToken: db[i].resetShortToken,
                 }
               )
       
@@ -244,7 +244,7 @@ const usersDb = [
                 [
                   'sendResetPwd',
                   sanitizeUserForEmail(db[i]),
-                  { transport: 'sms' }
+                  { passwordField: 'password', transport: 'sms' }
                 ]);
       
               done();

--- a/test/sendResetPwd.test.js
+++ b/test/sendResetPwd.test.js
@@ -271,7 +271,7 @@ function makeDateTime(options1) {
 }
 
 function aboutEqualDateTime(time1, time2, msg, delta) {
-  delta = delta || 1500;
+  delta = delta || 1700;
   const diff = Math.abs(time1 - time2);
   assert.isAtMost(diff, delta, msg || `times differ by ${diff}ms`);
 }

--- a/test/sendResetPwd.test.js
+++ b/test/sendResetPwd.test.js
@@ -57,8 +57,7 @@ const usersDb = [
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
 
@@ -102,8 +101,7 @@ const usersDb = [
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
       });
@@ -144,8 +142,7 @@ const usersDb = [
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
       });
@@ -186,8 +183,7 @@ const usersDb = [
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
       });
@@ -254,8 +250,7 @@ const usersDb = [
               done();
             })
             .catch(err => {
-              assert.strictEqual(err, null, 'err code set');
-              done();
+              done(err);
             });
         });
       });


### PR DESCRIPTION
### Summary

## Problem
 Currently there is no way to configure a custom password field name; it is hardcoded to look at the `password` field.

Im attempting to do the same logic for a `pin` field so having this ability to let the plugin know what field i'm trying to reset or change is valuable as to not rewrite all this code

The field name being updated is passed to the notifier as to give more information as to what was updated to build a proper email notification.

For eg. I want a different email if `password` or `pin` is being updated.

Also @feathersjs/authentication-local allows you to configure a custom password field, so this keeps it in line with that feature

This is backward compatible and doesn't introduce any breaking changes

## Related issues
#115 
#109 

## Other information

No dependencies
There are doc changes


Was receiving the following issue so had to update node version from 6 to 8 for the tests
```
/home/travis/build/feathers-plus/feathers-authentication-management/node_modules/feathers-hooks-common/lib/services/soft-delete-2.js:74
  return async function (context) {
               ^^^^^^^^
SyntaxError: Unexpected token function
    at createScript (vm.js:56:10)
```

Let me know if there are any issues with this.

Regards