### PR TITLE
Add actions to verify signup and set password simultaneously

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -43,6 +43,7 @@ provide much of the infrastructure necessary to implement such a scenario.
 ### User notifications may be sent for:
 
 - Sign up verification when a new user is created.
+- Sign up verification and initial password set when a new user is created.
 - Resending a signup verification, e.g. previous verification was lost or is expired.
 - Successful user verification.
 - Resetting the password when the password is forgotten.
@@ -114,12 +115,13 @@ app.configure(authentication)
 - skipIsVerifiedCheck: if `true` (default) it is impossible to reset password if email is not verified.
 - notifier: `function(type, user, notifierOptions)` returns a Promise.
    - type: type of notification
-     - 'resendVerifySignup'    From resendVerifySignup API call
-     - 'verifySignup'          From verifySignupLong and verifySignupShort API calls
-     - 'sendResetPwd'          From sendResetPwd API call
-     - 'resetPwd'              From resetPwdLong and resetPwdShort API calls
-     - 'passwordChange'        From passwordChange API call
-     - 'identityChange'        From identityChange API call
+     - 'resendVerifySignup'      From resendVerifySignup API call
+     - 'verifySignup'            From verifySignupLong and verifySignupShort API calls
+     - 'verifySignupSetPassword' From verifySignupSetPasswordLong and verifySignupSetPasswordShort API calls
+     - 'sendResetPwd'            From sendResetPwd API call
+     - 'resetPwd'                From resetPwdLong and resetPwdShort API calls
+     - 'passwordChange'          From passwordChange API call
+     - 'identityChange'          From identityChange API call
    - user: user's item, minus password.
    - notifierOptions: notifierOptions option from resendVerifySignup and sendResetPwd API calls
 - longTokenLen: Half the length of the long token. Default is 15, giving 30-char tokens.
@@ -212,6 +214,23 @@ authManagement.create({ action: 'verifySignupShort',
   }
 })
 
+// sign up verification and set password  with long token
+authManagement.create({ action: 'verifySignupSetPasswordLong',
+  value: {
+    token, // compares to .verifyToken
+    password, // new password
+  }
+})
+
+// sign up verification and set password with short token
+authManagement.create({ action: 'verifySignupSetPasswordShort',
+  value: {
+    user, // identify user, e.g. {email: 'a@a.com'}. See options.identifyUserProps.
+    token, // compares to .verifyShortToken
+    password, // new password
+  }
+})
+
 // send forgotten password notification
 authManagement.create({ action: 'sendResetPwd',
   value: identifyUser, // {email}, {token: verifyToken}
@@ -292,6 +311,12 @@ authManagement.verifySignupLong(verifyToken)
 
 // sign up or identityChange verification with short token
 authManagement.verifySignupShort(verifyShortToken, identifyUser)
+
+// sign up or identityChange verification with long token
+authManagement.verifySignupSetPasswordLong(verifyToken, password)
+
+// sign up or identityChange verification with short token
+authManagement.verifySignupSetPasswordShort(verifyShortToken, identifyUser, password)
 
 // send forgotten password notification
 authManagement.sendResetPwd(identifyUser, notifierOptions)

--- a/src/service.js
+++ b/src/service.js
@@ -96,7 +96,8 @@ function authLocalMgntMethods(options) {
             return await verifySignupSetPasswordWithLongToken(
               options,
               data.value.token,
-              data.value.password
+              data.value.password,
+              passwordField
             );
           } catch (err) {
             return Promise.reject(err);
@@ -107,28 +108,8 @@ function authLocalMgntMethods(options) {
               options,
               data.value.token,
               data.value.user,
-              data.value.password
-            );
-          } catch (err) {
-            return Promise.reject(err);
-          }
-        case "verifySignupSetPasswordLong":
-          try {
-            return await verifySignupSetPasswordWithLongToken(
-              options,
-              data.value.token,
-              data.value.password
-            );
-          } catch (err) {
-            return Promise.reject(err);
-          }
-        case "verifySignupSetPasswordShort":
-          try {
-            return await verifySignupSetPasswordWithShortToken(
-              options,
-              data.value.token,
-              data.value.user,
-              data.value.password
+              data.value.password,
+              passwordField
             );
           } catch (err) {
             return Promise.reject(err);

--- a/src/service.js
+++ b/src/service.js
@@ -12,6 +12,10 @@ const sanitizeUserForClient = require('./helpers/sanitize-user-for-client');
 const sendResetPwd = require('./send-reset-pwd');
 const { resetPwdWithLongToken, resetPwdWithShortToken } = require('./reset-password');
 const { verifySignupWithLongToken, verifySignupWithShortToken } = require('./verify-signup');
+const {
+  verifySignupSetPasswordWithLongToken,
+  verifySignupSetPasswordWithShortToken,
+} = require("./verify-signup-set-password");
 
 const optionsDefault = {
   app: null, // value set during configuration
@@ -65,6 +69,18 @@ function authLocalMgntMethods(options) {
         case 'verifySignupShort':
           try {
             return await verifySignupWithShortToken(options, data.value.token, data.value.user);
+          } catch (err) {
+            return Promise.reject(err);
+          }
+        case 'verifySignupSetPasswordLong':
+          try {
+            return await verifySignupSetPasswordWithLongToken(options, data.value.token, data.value.password)
+          } catch (err) {
+            return Promise.reject(err);
+          }
+        case 'verifySignupSetPasswordShort':
+          try {
+            return await verifySignupSetPasswordWithShortToken(options, data.value.token, data.value.user, data.value.password)
           } catch (err) {
             return Promise.reject(err);
           }

--- a/src/verify-signup-set-password.js
+++ b/src/verify-signup-set-password.js
@@ -1,0 +1,94 @@
+const errors = require("@feathersjs/errors");
+const makeDebug = require("debug");
+const ensureObjPropsValid = require("./helpers/ensure-obj-props-valid");
+const ensureValuesAreStrings = require("./helpers/ensure-values-are-strings");
+const getUserData = require("./helpers/get-user-data");
+const hashPassword = require("./helpers/hash-password");
+const notifier = require("./helpers/notifier");
+
+const debug = makeDebug("authLocalMgnt:verifySignupSetPassword");
+
+module.exports = {
+  verifySignupSetPasswordWithLongToken,
+  verifySignupSetPasswordWithShortToken,
+};
+
+async function verifySignupSetPasswordWithLongToken(
+  options,
+  verifyToken,
+  password
+) {
+  ensureValuesAreStrings(verifyToken, password);
+
+  return await verifySignupSetPassword(
+    options,
+    { verifyToken },
+    { verifyToken },
+    password
+  );
+}
+
+async function verifySignupSetPasswordWithShortToken(
+  options,
+  verifyShortToken,
+  identifyUser,
+  password
+) {
+  ensureValuesAreStrings(verifyShortToken, password);
+  ensureObjPropsValid(identifyUser, options.identifyUserProps);
+
+  return await verifySignupSetPassword(
+    options,
+    identifyUser,
+    {
+      verifyShortToken,
+    },
+    password
+  );
+}
+
+async function verifySignupSetPassword(options, query, tokens, password) {
+  debug("verifySignupSetPassword", query, tokens, password);
+  const usersService = options.app.service(options.service);
+  const usersServiceIdName = usersService.id;
+
+  const users = await usersService.find({ query });
+  const user1 = getUserData(users, [
+    "isNotVerifiedOrHasVerifyChanges",
+    "verifyNotExpired",
+  ]);
+
+  if (!Object.keys(tokens).every((key) => tokens[key] === user1[key])) {
+    await eraseVerifyPropsSetPassword(user1, user2.isVerified, {}, password);
+
+    throw new errors.BadRequest(
+      "Invalid token. Get for a new one. (authLocalMgnt)",
+      { errors: { $className: "badParam" } }
+    );
+  }
+
+  const user2 = await eraseVerifyPropsSetPassword(
+    user1,
+    user1.verifyExpires > Date.now(),
+    user1.verifyChanges || {},
+    password
+  );
+
+  const user3 = await notifier(options.notifier, "verifySignupSetPassword", user2);
+  return options.sanitizeUserForClient(user3);
+
+  async function eraseVerifyPropsSetPassword(user, isVerified, verifyChanges, password) {
+    const hashedPassword = await hashPassword(options.app, password);
+
+    const patchToUser = Object.assign({}, verifyChanges || {}, {
+      isVerified,
+      verifyToken: null,
+      verifyShortToken: null,
+      verifyExpires: null,
+      verifyChanges: {},
+      password: hashedPassword,
+    });
+
+    return await usersService.patch(user[usersServiceIdName], patchToUser, {});
+  }
+}

--- a/src/verify-signup-set-password.js
+++ b/src/verify-signup-set-password.js
@@ -16,7 +16,8 @@ module.exports = {
 async function verifySignupSetPasswordWithLongToken(
   options,
   verifyToken,
-  password
+  password,
+  field
 ) {
   ensureValuesAreStrings(verifyToken, password);
 
@@ -24,7 +25,8 @@ async function verifySignupSetPasswordWithLongToken(
     options,
     { verifyToken },
     { verifyToken },
-    password
+    password,
+    field
   );
 }
 
@@ -32,7 +34,8 @@ async function verifySignupSetPasswordWithShortToken(
   options,
   verifyShortToken,
   identifyUser,
-  password
+  password,
+  field
 ) {
   ensureValuesAreStrings(verifyShortToken, password);
   ensureObjPropsValid(identifyUser, options.identifyUserProps);
@@ -43,11 +46,12 @@ async function verifySignupSetPasswordWithShortToken(
     {
       verifyShortToken,
     },
-    password
+    password,
+    field
   );
 }
 
-async function verifySignupSetPassword(options, query, tokens, password) {
+async function verifySignupSetPassword(options, query, tokens, password, field) {
   debug("verifySignupSetPassword", query, tokens, password);
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
@@ -59,7 +63,7 @@ async function verifySignupSetPassword(options, query, tokens, password) {
   ]);
 
   if (!Object.keys(tokens).every((key) => tokens[key] === user1[key])) {
-    await eraseVerifyPropsSetPassword(user1, user2.isVerified, {}, password);
+    await eraseVerifyPropsSetPassword(user1, user2.isVerified, {}, password, field);
 
     throw new errors.BadRequest(
       "Invalid token. Get for a new one. (authLocalMgnt)",
@@ -71,14 +75,15 @@ async function verifySignupSetPassword(options, query, tokens, password) {
     user1,
     user1.verifyExpires > Date.now(),
     user1.verifyChanges || {},
-    password
+    password,
+    field
   );
 
   const user3 = await notifier(options.notifier, "verifySignupSetPassword", user2);
   return options.sanitizeUserForClient(user3);
 
-  async function eraseVerifyPropsSetPassword(user, isVerified, verifyChanges, password) {
-    const hashedPassword = await hashPassword(options.app, password);
+  async function eraseVerifyPropsSetPassword(user, isVerified, verifyChanges, password, field) {
+    const hashedPassword = await hashPassword(options.app, password, field);
 
     const patchToUser = Object.assign({}, verifyChanges || {}, {
       isVerified,

--- a/test/verify-signup-set-password-long.test.js
+++ b/test/verify-signup-set-password-long.test.js
@@ -1,0 +1,266 @@
+
+const assert = require('chai').assert;
+const feathers = require('@feathersjs/feathers');
+const feathersMemory = require('feathers-memory');
+const bcrypt = require("bcryptjs");
+const authLocalMgnt = require('../src/index');
+const SpyOn = require('./helpers/basic-spy');
+const { timeoutEachTest, maxTimeAllTests } = require('./helpers/config');
+
+const now = Date.now();
+
+const makeUsersService = (options) => function (app) {
+  app.use('/users', feathersMemory(options));
+};
+
+const usersId = [
+  { id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: now + maxTimeAllTests },
+  { id: 'b', email: 'b', isVerified: false, verifyToken: null, verifyExpires: null },
+  { id: 'c', email: 'c', isVerified: false, verifyToken: '111', verifyExpires: now - maxTimeAllTests },
+  { id: 'd', email: 'd', isVerified: true, verifyToken: '222', verifyExpires: now - maxTimeAllTests },
+  { id: 'e', email: 'e', isVerified: true, verifyToken: '800', verifyExpires: now + maxTimeAllTests,
+    verifyChanges: { cellphone: '800' } },
+];
+
+const users_Id = [
+  { _id: 'a', email: 'a', isVerified: false, verifyToken: '000', verifyExpires: now + maxTimeAllTests },
+  { _id: 'b', email: 'b', isVerified: false, verifyToken: null, verifyExpires: null },
+  { _id: 'c', email: 'c', isVerified: false, verifyToken: '111', verifyExpires: now - maxTimeAllTests },
+  { _id: 'd', email: 'd', isVerified: true, verifyToken: '222', verifyExpires: now - maxTimeAllTests },
+  { _id: 'e', email: 'e', isVerified: true, verifyToken: '800', verifyExpires: now + maxTimeAllTests,
+    verifyChanges: { cellphone: '800' } },
+];
+
+['_id', 'id'].forEach(idType => {
+  ['paginated', 'non-paginated'].forEach(pagination => {
+    describe(`verify-signup-set-password-long.js ${pagination} ${idType}`, function () {
+      this.timeout(timeoutEachTest);
+
+      describe('basic', () => {
+        let app;
+        let usersService;
+        let authLocalMgntService;
+        let db;
+        let result;
+
+        beforeEach(async () => {
+          app = feathers();
+          app.configure(makeUsersService({ id: idType, paginate: pagination === 'paginated' }));
+          app.configure(authLocalMgnt({
+
+          }));
+          app.setup();
+          authLocalMgntService = app.service('authManagement');
+
+          usersService = app.service('users');
+          await usersService.remove(null);
+          db = clone(idType === '_id' ? users_Id : usersId);
+          await usersService.create(db);
+        });
+
+        it('verifies valid token and sets password if not verified', async () => {
+          try {
+            const password = '123456';
+
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordLong',
+              value: {
+                token: '000',
+                password,
+              },
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'user.isVerified not true');
+
+            assert.strictEqual(user.isVerified, true, 'isVerified not true');
+            assert.strictEqual(user.verifyToken, null, 'verifyToken not null');
+            assert.strictEqual(user.verifyShortToken, null, 'verifyShortToken not null');
+            assert.strictEqual(user.verifyExpires, null, 'verifyExpires not null');
+            assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+            assert.isOk(bcrypt.compareSync(password, user.password), 'password is not hashed value');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('verifies valid token and sets password if verifyChanges', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordLong',
+              value: {
+                token: '800',
+                password,
+              },
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'user.isVerified not true');
+
+            assert.strictEqual(user.isVerified, true, 'isVerified not true');
+            assert.strictEqual(user.verifyToken, null, 'verifyToken not null');
+            assert.strictEqual(user.verifyShortToken, null, 'verifyShortToken not null');
+            assert.strictEqual(user.verifyExpires, null, 'verifyExpires not null');
+            assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+            assert.isOk(bcrypt.compareSync(password, user.password), 'password is not hashed value');
+            assert.strictEqual(user.cellphone, '800', 'cellphone wrong');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('user is sanitized', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordLong',
+              value: {
+                token: '000',
+                password,
+              },
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'isVerified not true');
+            assert.strictEqual(result.verifyToken, undefined, 'verifyToken not undefined');
+            assert.strictEqual(result.verifyShortToken, undefined, 'verifyShortToken not undefined');
+            assert.strictEqual(result.verifyExpires, undefined, 'verifyExpires not undefined');
+            assert.strictEqual(result.verifyChanges, undefined, 'verifyChanges not undefined');
+            assert.isOk(bcrypt.compareSync(password, user.password), 'password is not hashed value');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('error on verified user without verifyChange', async () => {
+          try {
+            result = await authLocalMgntService.create({
+                action: 'verifySignupSetPasswordLong',
+                value: {
+                  token: '222',
+                  password: '12456',
+                },
+              },
+              {},
+              (err, user) => {}
+            );
+
+            assert(fail, 'unexpectedly succeeded');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('error on expired token', async () => {
+          try {
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordLong',
+              value: {
+                token: '111',
+                password: '123456',
+              },
+            });
+
+            assert(fail, 'unexpectedly succeeded');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('error on token not found', async () => {
+          try {
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordLong',
+              value: {
+                token: '999',
+                password: '123456',
+              },
+            });
+
+            assert(fail, 'unexpectedly succeeded');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+      });
+
+      describe('with notification', () => {
+        let app;
+        let usersService;
+        let authLocalMgntService;
+        let db;
+        let result;
+        let spyNotifier;
+
+        beforeEach(async () => {
+          spyNotifier = new SpyOn(notifier);
+
+          app = feathers();
+          app.configure(makeUsersService({ id: idType, paginate: pagination === 'paginated' }));
+          app.configure(authLocalMgnt({
+            notifier: spyNotifier.callWith, testMode: true
+          }));
+          app.setup();
+          authLocalMgntService = app.service('authManagement');
+
+          usersService = app.service('users');
+          await usersService.remove(null);
+          db = clone(idType === '_id' ? users_Id : usersId);
+          await usersService.create(db);
+        });
+
+        it('verifies valid token and sets password', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordLong',
+              value: {
+                token: '000',
+                password,
+              },
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'user.isVerified not true');
+
+            assert.strictEqual(user.isVerified, true, 'isVerified not true');
+            assert.strictEqual(user.verifyToken, null, 'verifyToken not null');
+            assert.strictEqual(user.verifyExpires, null, 'verifyExpires not null');
+            assert.isOk(bcrypt.compareSync(password, user.password), 'password is not hashed value');
+            assert.deepEqual(spyNotifier.result()[0].args, [
+              "verifySignupSetPassword",
+              Object.assign({}, sanitizeUserForEmail(user)),
+              {},
+            ]);
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+      });
+    });
+  });
+});
+
+// Helpers
+
+async function notifier(action, user, notifierOptions, newEmail) {
+  return user;
+}
+
+function sanitizeUserForEmail(user) {
+  const user1 = Object.assign({}, user);
+  delete user1.password;
+  return user1;
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/verify-signup-set-password-short.test.js
+++ b/test/verify-signup-set-password-short.test.js
@@ -1,0 +1,343 @@
+
+const assert = require('chai').assert;
+const feathers = require('@feathersjs/feathers');
+const feathersMemory = require('feathers-memory');
+const bcrypt = require("bcryptjs");
+const authLocalMgnt = require('../src/index');
+const SpyOn = require('./helpers/basic-spy');
+const { timeoutEachTest, maxTimeAllTests } = require('./helpers/config');
+
+const now = Date.now();
+
+const makeUsersService = (options) => function (app) {
+  app.use('/users', feathersMemory(options));
+};
+
+const usersId = [
+  { id: 'a', email: 'a', username: 'aa', isVerified: false, verifyToken: '000', verifyShortToken: '00099', verifyExpires: now + maxTimeAllTests },
+  { id: 'b', email: 'b', username: 'bb', isVerified: false, verifyToken: null, verifyShortToken: null, verifyExpires: null },
+  { id: 'c', email: 'c', username: 'cc', isVerified: false, verifyToken: '111', verifyShortToken: '11199', verifyExpires: now - maxTimeAllTests },
+  { id: 'd', email: 'd', username: 'dd', isVerified: true, verifyToken: '222', verifyShortToken: '22299', verifyExpires: now - maxTimeAllTests },
+  { id: 'e', email: 'e', username: 'ee', isVerified: true, verifyToken: '800', verifyShortToken: '80099', verifyExpires: now + maxTimeAllTests,
+    verifyChanges: { cellphone: '800' } },
+];
+
+const users_Id = [
+  { _id: 'a', email: 'a', username: 'aa', isVerified: false, verifyToken: '000', verifyShortToken: '00099', verifyExpires: now + maxTimeAllTests },
+  { _id: 'b', email: 'b', username: 'bb', isVerified: false, verifyToken: null, verifyShortToken: null, verifyExpires: null },
+  { _id: 'c', email: 'c', username: 'cc', isVerified: false, verifyToken: '111', verifyShortToken: '11199', verifyExpires: now - maxTimeAllTests },
+  { _id: 'd', email: 'd', username: 'dd', isVerified: true, verifyToken: '222', verifyShortToken: '22299', verifyExpires: now - maxTimeAllTests },
+  { _id: 'e', email: 'e', username: 'ee', isVerified: true, verifyToken: '800', verifyShortToken: '80099', verifyExpires: now + maxTimeAllTests,
+    verifyChanges: { cellphone: '800' } },
+];
+
+['_id', 'id'].forEach(idType => {
+  ['paginated', 'non-paginated'].forEach(pagination => {
+    describe(`verify-signUp-short.js ${pagination} ${idType}`, function () {
+      this.timeout(timeoutEachTest);
+
+      describe('basic', () => {
+        let app;
+        let usersService;
+        let authLocalMgntService;
+        let db;
+        let result;
+
+        beforeEach(async () => {
+          app = feathers();
+          app.configure(makeUsersService({ id: idType, paginate: pagination === 'paginated' }));
+          app.configure(authLocalMgnt({
+            identifyUserProps: ['email', 'username'],
+          }));
+          app.setup();
+          authLocalMgntService = app.service('authManagement');
+
+          usersService = app.service('users');
+          await usersService.remove(null);
+          db = clone(idType === '_id' ? users_Id : usersId);
+          await usersService.create(db);
+        });
+
+        it('verifies valid token and sets password if not verified', async () => {
+          try {
+            const password = '123456'
+            result = await authLocalMgntService.create({ action: 'verifySignupSetPasswordShort', value: {
+                token: '00099',
+                user: { email: db[0].email },
+                password,
+              }
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'user.isVerified not true');
+
+            assert.strictEqual(user.isVerified, true, 'isVerified not true');
+            assert.strictEqual(user.verifyToken, null, 'verifyToken not null');
+            assert.strictEqual(user.verifyShortToken, null, 'verifyShortToken not null');
+            assert.strictEqual(user.verifyExpires, null, 'verifyExpires not null');
+            assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('verifies valid token and sets password if verifyChanges', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({ action: 'verifySignupSetPasswordShort', value: {
+                token: '80099',
+                user: { email: db[4].email },
+                password,
+              }
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'user.isVerified not true');
+
+            assert.strictEqual(user.isVerified, true, 'isVerified not true');
+            assert.strictEqual(user.verifyToken, null, 'verifyToken not null');
+            assert.strictEqual(user.verifyShortToken, null, 'verifyShortToken not null');
+            assert.strictEqual(user.verifyExpires, null, 'verifyExpires not null');
+            assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+            assert.isOk(bcrypt.compareSync(password, user.password), 'password is not hashed value');
+
+            assert.strictEqual(user.cellphone, '800', 'cellphone wrong');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('user is sanitized', async () => {
+          try {
+            result = await authLocalMgntService.create({ action: 'verifySignupSetPasswordShort', value: {
+                token: '00099',
+                user: { username: db[0].username },
+                password: '123456'
+             }
+            });
+
+            assert.strictEqual(result.isVerified, true, 'isVerified not true');
+            assert.strictEqual(result.verifyToken, undefined, 'verifyToken not undefined');
+            assert.strictEqual(result.verifyShortToken, undefined, 'verifyShortToken not undefined');
+            assert.strictEqual(result.verifyExpires, undefined, 'verifyExpires not undefined');
+            assert.strictEqual(result.verifyChanges, undefined, 'verifyChanges not undefined');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('handles multiple user ident', async () => {
+          try {
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '00099',
+                user: { email: db[0].email, username: db[0].username },
+                password: '123456',
+              }
+            });
+
+            assert.strictEqual(result.isVerified, true, 'isVerified not true');
+            assert.strictEqual(result.verifyToken, undefined, 'verifyToken not undefined');
+            assert.strictEqual(result.verifyShortToken, undefined, 'verifyShortToken not undefined');
+            assert.strictEqual(result.verifyExpires, undefined, 'verifyExpires not undefined');
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+
+        it('requires user ident', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '00099',
+                user: {},
+                password,
+              }
+            });
+
+            assert(false, 'unexpectedly succeeded.');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('throws on non-configured user ident', async () => {
+          try {
+            const password= '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '00099',
+                user: { email: db[i].email, verifyShortToken: '00099' },
+                password,
+              }
+            });
+
+            assert(false, 'unexpectedly succeeded.');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('error on unverified user', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '22299',
+                user: { email: db[3].email },
+                password,
+              }
+            });
+
+            assert(false, 'unexpectedly succeeded.');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('error on expired token', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '11199',
+                user: { username: db[2].username }
+              },
+              password,
+            });
+
+            assert(false, 'unexpectedly succeeded.');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('error on user not found', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '999',
+                user: { email: '999' },
+                password,
+              }
+            });
+
+            assert(false, 'unexpectedly succeeded.');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+
+        it('error incorrect token', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: { token: '999', user: { email: db[0].email }, password }
+            });
+
+            assert(false, 'unexpectedly succeeded.');
+          } catch (err) {
+            assert.isString(err.message);
+            assert.isNotFalse(err.message);
+          }
+        });
+      });
+
+      describe('with notification', () => {
+        let spyNotifier;
+
+        let app;
+        let usersService;
+        let authLocalMgntService;
+        let db;
+        let result;
+
+        beforeEach(async () => {
+          spyNotifier = new SpyOn(notifier);
+
+          app = feathers();
+          app.configure(makeUsersService({ id: idType, paginate: pagination === 'paginated' }));
+          app.configure(authLocalMgnt({
+            // maybe reset identifyUserProps
+            notifier: spyNotifier.callWith,
+            testMode: true,
+          }));
+          app.setup();
+          authLocalMgntService = app.service('authManagement');
+
+          usersService = app.service('users');
+          await usersService.remove(null);
+          db = clone(idType === '_id' ? users_Id : usersId);
+          await usersService.create(db);
+        });
+        
+        it('verifies valid token and sets password', async () => {
+          try {
+            const password = '123456';
+            result = await authLocalMgntService.create({
+              action: 'verifySignupSetPasswordShort',
+              value: {
+                token: '00099',
+                user: { email: db[0].email },
+                password,
+              },
+            });
+            const user = await usersService.get(result.id || result._id);
+
+            assert.strictEqual(result.isVerified, true, 'user.isVerified not true');
+
+            assert.strictEqual(user.isVerified, true, 'isVerified not true');
+            assert.strictEqual(user.verifyToken, null, 'verifyToken not null');
+            assert.strictEqual(user.verifyShortToken, null, 'verifyShortToken not null');
+            assert.strictEqual(user.verifyExpires, null, 'verifyExpires not null');
+            assert.deepEqual(user.verifyChanges, {}, 'verifyChanges not empty object');
+            assert.isOk(bcrypt.compareSync(password, user.password), 'password is not hashed value');
+
+            assert.deepEqual( spyNotifier.result()[0].args, [
+              'verifySignupSetPassword',
+              Object.assign({}, sanitizeUserForEmail(user)),
+              {}
+            ]);
+          } catch (err) {
+            console.log(err);
+            assert(false, 'err code set');
+          }
+        });
+      });
+    });
+  });
+});
+
+// Helpers
+
+async function notifier(action, user, notifierOptions, newEmail) {
+  return user;
+}
+
+function sanitizeUserForEmail(user) {
+  const user1 = Object.assign({}, user);
+  delete user1.password;
+  return user1;
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
### Summary

This PR implements new actions 'verifySignupSetPasswordLong' and  'verifySignupSetPasswordShort', which allow you to both verify an account and set the user password simultaneously.

This supports the account setup flow in which an administrator creates a user account without a password, and then the user sets their password and verifies their account with a single service call.

Tests and documentation are included.